### PR TITLE
Addition of EOL disclaimer & title change for clearness to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
+###### No longer being maintained. Check [Discord Classic by bag.xml](https://github.com/bag-xml/Discord-Classic) instead. Newer versions from version 0.9 onwards can be found there.
+<br/>
 <div align="center">
 <img src="https://github.com/user-attachments/assets/367c10d2-234a-41c9-933c-c4b494d5c185" height="128" width="128" style="border-radius:25%">
-   <h1> Discord Classic (continuation)
+   <h1> Discord Classic I 0.8.8 pr1-pr8
       <br/> <h3 align="center"> Discord client for Legacy iOS with enhanced UI and additional features
    </h1>
 </div>


### PR DESCRIPTION
I feel like this makes the most sense, considering that's the project that's now in development actively. We now have three different Discord Classics and since it's already confusing, I made this small addition to the title as well. Now everyone should be able to get to the newest versions relatively easily. Hope you see it the same way :)